### PR TITLE
[RBA-59] Added commandline parameter to disable chromium address bar

### DIFF
--- a/base/base_switches.cc
+++ b/base/base_switches.cc
@@ -185,4 +185,7 @@ const char kPackageVersionName[] = "package-version-name";
 const char kSchedulerBoostUrgent[] = "scheduler-boost-urgent";
 #endif
 
+// Will check whether the location bar view needs to be disabled.
+const char kDisableAddressBar[] = "disable-address-bar";
+
 }  // namespace switches

--- a/base/base_switches.h
+++ b/base/base_switches.h
@@ -64,6 +64,7 @@ extern const char kPackageVersionName[];
 extern const char kSchedulerBoostUrgent[];
 #endif
 
+extern const char kDisableAddressBar[];
 }  // namespace switches
 
 #endif  // BASE_BASE_SWITCHES_H_

--- a/chrome/browser/ui/views/location_bar/location_bar_view.cc
+++ b/chrome/browser/ui/views/location_bar/location_bar_view.cc
@@ -9,6 +9,8 @@
 #include <memory>
 #include <utility>
 
+#include "base/base_switches.h"
+#include "base/command_line.h"
 #include "base/containers/adapters.h"
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
@@ -225,6 +227,11 @@ LocationBarView::LocationBarView(Browser* browser,
 
 LocationBarView::~LocationBarView() = default;
 
+// Method to disable the Omnibox
+void LocationBarView::DisableOmnibox() {
+  omnibox_view_->SetEnabled(false);
+}
+
 void LocationBarView::Init() {
   // We need to be in a Widget, otherwise GetNativeTheme() may change and we're
   // not prepared for that.
@@ -277,7 +284,10 @@ void LocationBarView::Init() {
   // the former will focus the latter. In order to receive |ShowContextMenu()|
   // requests, LocationBarView must have a context menu controller.
   set_context_menu_controller(omnibox_view_->context_menu_controller());
-
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kDisableAddressBar)) {
+    DisableOmnibox();
+  }
   RefreshBackground();
 
   // Initialize the IME autocomplete labels which are visible only when IME is

--- a/chrome/browser/ui/views/location_bar/location_bar_view.h
+++ b/chrome/browser/ui/views/location_bar/location_bar_view.h
@@ -329,6 +329,7 @@ class LocationBarView
   LocationBarTesting* GetLocationBarForTesting() override;
   void OnChanged() override;
   void OnPopupVisibilityChanged() override;
+  void DisableOmnibox();
 
   // LocationBarTesting:
   bool TestContentSettingImagePressed(size_t index) override;


### PR DESCRIPTION
Added command line parameter `--disable-address-bar`. If this option is provided while starting chromium browser, it disables editing the location bar view.

Fixes #(https://macrometa.atlassian.net/browse/RBA-59)